### PR TITLE
Enable fnPop function to be passed

### DIFF
--- a/R/DEoptim.R
+++ b/R/DEoptim.R
@@ -73,7 +73,7 @@ DEoptim.control <- function(VTR = -Inf, strategy = 2, bs = FALSE, NP = NA,
            foreachArgs)
 }
 
-DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...,
+DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ..., fnPop = NULL,
                     fnMap=NULL) {
   if (length(lower) != length(upper))
     stop("'lower' and 'upper' are not of same length")
@@ -122,6 +122,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...,
   ctrl$trace <- as.numeric(ctrl$trace)
   ctrl$specinitialpop <- as.numeric(ctrl$specinitialpop)
   ctrl$initialpop <- as.numeric(ctrl$initialpop)
+  if (is.null(fnPop)) {
   if(!is.null(ctrl$cluster)) { ## use provided cluster
     if(!inherits(ctrl$cluster, "cluster"))
       stop("cluster is not a 'cluster' class object")
@@ -173,6 +174,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...,
     fnPop <- function(params, ...) {
       apply(params,1,fn,...)
     }
+  }
   }
 
   ## Mapping function


### PR DESCRIPTION
This makes it easy to implement your own parallelisation by integrating
that into the fnPop function.

For example I use it with the future.apply package as follows:

```R
fnPop <- function(params, ...) {
      future.apply::future_apply(X = params, MARGIN = 1, FUN = myFunction, ...)
}

opt <- DEoptim(lower = rep(-3, length(init_par)), upper = rep(3, length(init_par)), 
                   fnPop = fnPop, control = list(itermax = 100, strategy = 6))
```