### PR TITLE
issues related to `cluster` argument

### DIFF
--- a/R/DEoptim.R
+++ b/R/DEoptim.R
@@ -125,6 +125,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...,
     if(!is.null(ctrl$cluster)) { ## use provided cluster
         if(!inherits(ctrl$cluster, "cluster"))
             stop("cluster is not a 'cluster' class object")
+        cl = ctrl$cluster
         parallel::clusterExport(cl, ctrl$parVar)
         fnPop <- function(params, ...) {
             parallel::parApply(cl=ctrl$cluster,params,1,fn,...)
@@ -209,7 +210,7 @@ DEoptim <- function(fn, lower, upper, control = DEoptim.control(), ...,
 
   outC <- .Call("DEoptimC", lower, upper, fnPop, ctrl, new.env(), fnMapC, PACKAGE="DEoptim")
 
-  if(ctrl$parallelType == 1)
+  if (is.null(ctrl$cluster) && (ctrl$parallelType == 1))
     parallel::stopCluster(cl) 
   
   if (length(outC$storepop) > 0) {


### PR DESCRIPTION
For the first one, `cl` has not been defined on L128, for a non-NULL `parVar`, it throws
```r
Error in parallel::clusterExport(cl, ctrl$parVar) : object 'cl' not found
```
although in practice it does not throw an error when `ctrl$parVar` is `NULL`,

For the second one, `cl` is provided outside via `cluster` argument, and it should not be stopped inside. The `stopCluster` operation is for `parallelType=1`, but `parallelType=1` also implies `cluster` is NULL based on the `ifelse` block from L125 to L160. If someone sets `parallelType=1` and a custom `cluster` simultaneously, it would be problematic. So alternatively, another solution might be to disallow to set `parallelType=1` and `cluster` simultaneously.